### PR TITLE
Fix tests by passing in gas limit

### DIFF
--- a/src/core/AlpineDeFiSDK.ts
+++ b/src/core/AlpineDeFiSDK.ts
@@ -280,7 +280,10 @@ async function _blockchainCall(
     return;
   }
 
-  const tx = await contract[method].apply(null, args);
+  const tx = await contract[method].apply(
+    null,
+    args.concat({ gasLimit: 15e6 })
+  );
   await tx.wait();
 }
 

--- a/src/core/package.json
+++ b/src/core/package.json
@@ -19,7 +19,7 @@
     "concurrently": "^7.0.0",
     "dotenv": "^16.0.0",
     "ethereum-waffle": "^3.4.0",
-    "ganache": "^7.0.2",
+    "ganache": "^7.0.3",
     "mocha": "^9.2.1",
     "ts-node": "^10.5.0"
   }

--- a/src/core/test/product.test.ts
+++ b/src/core/test/product.test.ts
@@ -45,10 +45,10 @@ describe("Buy products", async () => {
     const res: ethers.BigNumber = await CONTRACTS.alpLarge.balanceOf(
       wallet.address
     );
-    console.log("alpLarge shares....", res);
+    console.log("alpLarge shares....", res.toString());
     assert(res.gt(0));
 
-    await sellProduct("alpLarge", 0.1);
+    await sellProduct("alpLarge", 10);
     const newBal: ethers.BigNumber = await CONTRACTS.alpLarge.balanceOf(
       wallet.address
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -4404,7 +4404,7 @@ __metadata:
     dotenv: ^16.0.0
     ethereum-waffle: ^3.4.0
     ethers: ^5.5.4
-    ganache: ^7.0.2
+    ganache: ^7.0.3
     mocha: ^9.2.1
     ts-node: ^10.5.0
   languageName: unknown
@@ -6796,9 +6796,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ganache@npm:^7.0.2":
-  version: 7.0.2
-  resolution: "ganache@npm:7.0.2"
+"ganache@npm:^7.0.3":
+  version: 7.0.3
+  resolution: "ganache@npm:7.0.3"
   dependencies:
     "@trufflesuite/bigint-buffer": 1.1.9
     bufferutil: 4.0.5
@@ -6815,7 +6815,7 @@ __metadata:
   bin:
     ganache: dist/node/cli.js
     ganache-cli: dist/node/cli.js
-  checksum: 43b77070b8b801879eed083114618a5fc657d0ebc97c5c9c422ab9f4b69489fcf6fe42791823e98814bf19fae3a0421dccbaa2c0e44a8f4f638f644e8b6ac0d3
+  checksum: 4e1a478150e08c9f1a269529fb040fcec60109a10724695ea5d321aa2184438ad30899a7b40361764da82cbc9de389bce960872ae5cff6718db78c2e98882e29
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Ganache seems to think that selling alpLarge should take ~238604 gas, but it takes ~226464 gas.

- We use the target block gas limit of 15 million