### PR TITLE
Resolved magic logout

### DIFF
--- a/src/frontend/Account.ts
+++ b/src/frontend/Account.ts
@@ -119,7 +119,7 @@ class Account {
    * Disconnect a user from the magic provider
    */
   async disconnect(): Promise<void> {
-    if (this.magic && (await this.magic.user.isLoggedIn())) await this.magic.user.logout();
+    if (this.magic?.user) await this.magic.user.logout();
     this.magicDidToken = null;
   }
 


### PR DESCRIPTION
The Magic `isLoggedIn()` checks the validity of DID token. Which is why it returns `false` even if the JWT token is still valid. So we need to remove the `isLoggedIn()` check for `logout()`