### PR TITLE
Fix walletConnect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alpine-ramp/alpine-defi-sdk",
-  "version": "1.0.2-beta",
+  "version": "1.0.4-beta",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/Multiplyr/defi-sdk.git",

--- a/src/frontend/test.ts
+++ b/src/frontend/test.ts
@@ -58,8 +58,8 @@ const connectAndWrite = async ({
 const main = async () => {
   const alpAccount = new Account();
 
-  await alpAccount.switchWalletToAllowedNetwork("metamask", DEFAULT_RAW_CHAIN_ID);
-  await connectAndWrite({ account: alpAccount, chainId: DEFAULT_RAW_CHAIN_ID });
+  await alpAccount.switchWalletToAllowedNetwork("walletConnect", 137);
+  await connectAndWrite({ walletType: "walletConnect", account: alpAccount, chainId: 137 });
   await alpAccount.switchWalletToAllowedNetwork("metamask", 5);
   await connectAndWrite({ account: alpAccount, chainId: 5 });
   console.log("exiting");

--- a/src/frontend/wallets.ts
+++ b/src/frontend/wallets.ts
@@ -90,7 +90,7 @@ export async function getWeb3Provider(
     case "walletConnect": {
       const provider = new WalletConnectProvider({
         rpc: {
-          [chainId]: RPC_URLS[chainId],
+          ...RPC_URLS,
         },
       });
 


### PR DESCRIPTION
If the user selects any selected chain, an rpc url will be found. Currently, if there's a mismatch between the chain the user selects and chainId passed to getWeb3Provider then we get an error.