### PR TITLE
ALP-3963 - Skip checking `isConnected` before connect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alpine-ramp/alpine-defi-sdk",
-  "version": "1.2.1-beta",
+  "version": "1.2.2-beta",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/Multiplyr/defi-sdk.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alpine-ramp/alpine-defi-sdk",
-  "version": "1.2.0-beta",
+  "version": "1.2.1-beta",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/Multiplyr/defi-sdk.git",

--- a/src/frontend/Account.ts
+++ b/src/frontend/Account.ts
@@ -8,7 +8,7 @@ import { ethers } from "ethers";
 import { EmergencyWithdrawalQueueRequest, EmergencyWithdrawalQueueTransfer, productAllocation } from "../core/types";
 import { portfolioSell, portfolioPurchase } from "../core/portfolio";
 import { AlpineDeFiSDK, init } from "../core";
-import { AlpineProduct, AlpineContracts } from "../core/types";
+import { AlpineProduct } from "../core/types";
 import * as productActions from "../core/product";
 import { setSimulationMode } from "../core/cache";
 import { AllowedChainId, AllowedWallet, IConnectAccount, MetamaskError } from "../types/account";
@@ -61,9 +61,6 @@ class Account {
     verify,
     chainId,
   }: IConnectAccount): Promise<void> {
-    console.log("connected: ", this.isConnected(walletType, chainId));
-    if (this.isConnected(walletType, chainId)) return;
-
     // get wallet provider based on wallet type
     let walletProvider: ethers.providers.Web3Provider | undefined;
     if (walletType === "magic" && email) {


### PR DESCRIPTION
Frontend already maintains the state of `isWalletConnected` in a context. So checking `isConnected` before `connect` creates issues when a user tries to reconnect in the same tab/ without any browser refresh. Also, this is redundant to check/ maintain the `isConnected` state both on the SDK & FE. That's why I removed the check for `isConnected` before the `connect` function.