### PR TITLE
Skipping initialization of unavailable vaults (testnets)

### DIFF
--- a/dist/core/AlpineDeFiSDK.js
+++ b/dist/core/AlpineDeFiSDK.js
@@ -125,6 +125,7 @@ exports.blockchainCall = blockchainCall;
  * @returns boolean
  */
 function isApproved(product, amount) {
+    var _a;
     return __awaiter(this, void 0, void 0, function* () {
         const { usdc, alpSave, router, ethEarn, ssvEthUSDEarn, degen, polygonDegen, ethLeverage, weth, polygonLeverage } = (0, cache_1.getContracts)();
         if (product === "ethWethEarn")
@@ -140,7 +141,10 @@ function isApproved(product, amount) {
             ethLeverage,
             polygonLeverage,
         };
-        const allowance = yield asset.allowance(cache_1.userAddress, productToSpender[product].address);
+        if (!productToSpender[product]) {
+            throw new Error("Product not found");
+        }
+        const allowance = yield asset.allowance(cache_1.userAddress, (_a = productToSpender[product]) === null || _a === void 0 ? void 0 : _a.address);
         /**
          * If the 'amount' is not specified then we will check the max amount, but
          * we are dividing the max approval amount by 2 because
@@ -162,6 +166,7 @@ exports.isApproved = isApproved;
  * @param amountUSDC (optional) transaction amount in usdc, if not specified then approve max amount
  */
 function approve(product, amountAsset) {
+    var _a;
     return __awaiter(this, void 0, void 0, function* () {
         const contracts = (0, cache_1.getContracts)();
         const { usdc, router, weth } = contracts;
@@ -177,7 +182,7 @@ function approve(product, amountAsset) {
             dollarAmount: amountAsset || _removeDecimals(constants_1.MAX_APPROVAL_AMOUNT, decimals),
             tokenAmount: amountAsset || _removeDecimals(constants_1.MAX_APPROVAL_AMOUNT, decimals),
         };
-        const approveArgs = [product === "alpLarge" ? router.address : contracts[product].address, amount];
+        const approveArgs = [product === "alpLarge" ? router.address : (_a = contracts[product]) === null || _a === void 0 ? void 0 : _a.address, amount];
         if (cache_1.SIMULATE) {
             const dryRunInfo = (yield blockchainCall(asset, "approve", approveArgs, true));
             return Object.assign(Object.assign({}, basicInfo), dryRunInfo);
@@ -231,6 +236,8 @@ function mintWhitelist(quantity, proof) {
     return __awaiter(this, void 0, void 0, function* () {
         const contracts = (0, cache_1.getContracts)();
         const { affineGenesis } = contracts;
+        if (!affineGenesis)
+            throw new Error("AffineGenesis contract not found");
         return blockchainCall(affineGenesis, "mintWhitelist", [quantity, proof]);
     });
 }
@@ -243,6 +250,8 @@ function mint(quantity) {
     return __awaiter(this, void 0, void 0, function* () {
         const contracts = (0, cache_1.getContracts)();
         const { affineGenesis } = contracts;
+        if (!affineGenesis)
+            throw new Error("AffineGenesis contract not found");
         return blockchainCall(affineGenesis, "mint", [quantity]);
     });
 }
@@ -252,10 +261,11 @@ exports.mint = mint;
  * @returns boolean
  */
 function isWhitelisted(address, proof) {
+    var _a;
     return __awaiter(this, void 0, void 0, function* () {
         const contracts = (0, cache_1.getContracts)();
         const { affineGenesis } = contracts;
-        return affineGenesis.isWhitelisted(address, proof);
+        return (_a = affineGenesis === null || affineGenesis === void 0 ? void 0 : affineGenesis.isWhitelisted(address, proof)) !== null && _a !== void 0 ? _a : false;
     });
 }
 exports.isWhitelisted = isWhitelisted;
@@ -264,10 +274,11 @@ exports.isWhitelisted = isWhitelisted;
  * @returns boolean
  */
 function whitelistSaleIsActive() {
+    var _a;
     return __awaiter(this, void 0, void 0, function* () {
         const contracts = (0, cache_1.getContracts)();
         const { affineGenesis } = contracts;
-        return affineGenesis.whitelistSaleIsActive();
+        return (_a = affineGenesis === null || affineGenesis === void 0 ? void 0 : affineGenesis.whitelistSaleIsActive()) !== null && _a !== void 0 ? _a : false;
     });
 }
 exports.whitelistSaleIsActive = whitelistSaleIsActive;
@@ -276,10 +287,11 @@ exports.whitelistSaleIsActive = whitelistSaleIsActive;
  * @returns boolean
  */
 function saleIsActive() {
+    var _a;
     return __awaiter(this, void 0, void 0, function* () {
         const contracts = (0, cache_1.getContracts)();
         const { affineGenesis } = contracts;
-        return affineGenesis.saleIsActive();
+        return (_a = affineGenesis === null || affineGenesis === void 0 ? void 0 : affineGenesis.saleIsActive()) !== null && _a !== void 0 ? _a : false;
     });
 }
 exports.saleIsActive = saleIsActive;

--- a/dist/core/cache.js
+++ b/dist/core/cache.js
@@ -75,8 +75,8 @@ function getAllContracts(provider, version) {
                 router: typechain_1.Router__factory.connect(router.address, provider),
                 ewQueue: typechain_1.EmergencyWithdrawalQueue__factory.connect(yield alpSave.emergencyWithdrawalQueue(), provider),
                 polygonDegen: typechain_1.StrategyVault__factory.connect(polygonDegenData.address, provider),
-                polygonLeverage: typechain_1.Vault__factory.connect(polygonLeverageData.address, provider),
-                affineGenesis: typechain_1.AffineGenesis__factory.connect(affineGenesisData.address, provider),
+                polygonLeverage: chainId === 137 ? typechain_1.Vault__factory.connect(polygonLeverageData.address, provider) : undefined,
+                affineGenesis: chainId === 137 ? typechain_1.AffineGenesis__factory.connect(affineGenesisData.address, provider) : undefined,
             };
         }
         else if (chainId === 1 || chainId === 5) {
@@ -85,7 +85,7 @@ function getAllContracts(provider, version) {
             const ssvEthUSDEarn = typechain_1.StrategyVault__factory.connect(ssvEthSushiUSDEarn.address, provider);
             const withdrawalEscrow = typechain_1.WithdrawalEscrow__factory.connect(yield ssvEthUSDEarn.debtEscrow(), provider);
             const degen = typechain_1.Vault__factory.connect(degenData.address, provider);
-            const ethLeverage = typechain_1.Vault__factory.connect(ethLeverageData.address, provider);
+            const ethLeverage = chainId === 1 ? typechain_1.Vault__factory.connect(ethLeverageData.address, provider) : undefined;
             return {
                 ethEarn,
                 ethWethEarn,

--- a/dist/core/product.js
+++ b/dist/core/product.js
@@ -34,6 +34,8 @@ function _getVaultAndAsset(product) {
             polygonLeverage,
         };
         const vault = productToVault[product];
+        if (!vault)
+            throw new Error("Invalid product");
         const asset = typechain_1.MockERC20__factory.connect(yield vault.asset(), vault.provider);
         const router = product in types_1.polygonProducts ? polyRouter : ethRouter;
         return { vault, asset, router };
@@ -240,6 +242,8 @@ function getTokenInfo(product) {
         else {
             contract = (0, cache_1.getPolygonContracts)()[product];
         }
+        if (!contract)
+            throw new Error("Invalid product");
         const amount = yield contract.balanceOf(user);
         // price number of decimals of the share token
         const { num, decimals } = yield contract.detailedPrice();

--- a/dist/core/types.d.ts
+++ b/dist/core/types.d.ts
@@ -42,8 +42,8 @@ export interface PolygonContracts extends BothContracts {
     router: Router;
     ewQueue: EmergencyWithdrawalQueue;
     polygonDegen: StrategyVault;
-    polygonLeverage: Vault;
-    affineGenesis: AffineGenesis;
+    polygonLeverage?: Vault;
+    affineGenesis?: AffineGenesis;
 }
 export interface EthContracts extends BothContracts {
     ethEarn: Vault;
@@ -53,7 +53,7 @@ export interface EthContracts extends BothContracts {
     withdrawalEscrow: WithdrawalEscrow;
     router: Router;
     degen: Vault;
-    ethLeverage: Vault;
+    ethLeverage?: Vault;
 }
 export interface AlpineContracts extends PolygonContracts, EthContracts {
 }

--- a/dist/frontend/test.js
+++ b/dist/frontend/test.js
@@ -76,8 +76,8 @@ const buy = (alpAccount, product, amount) => __awaiter(void 0, void 0, void 0, f
 const main = () => __awaiter(void 0, void 0, void 0, function* () {
     const alpAccount = new Account_1.Account();
     const walletType = "metamask";
-    const chainId = 137;
-    const _productToBuy = "polygonLeverage";
+    const chainId = 5;
+    const _productToBuy = "ethEarn";
     console.log(`connecting to ${walletType} on chain ${chainId}`, { ALLOWED_CHAIN_IDS: constants_1.ALLOWED_CHAIN_IDS }, constants_1.ALLOWED_CHAIN_IDS.map(c => `eip155:${c}`));
     yield connectAndWrite({ walletType, account: alpAccount, chainId });
     const readAcc = new Account_1.ReadAccount(alpAccount.userAddress || "", chainId);
@@ -85,8 +85,8 @@ const main = () => __awaiter(void 0, void 0, void 0, function* () {
     console.log("usdc bal: ", yield readAcc.getTokenInfo("usdc"));
     console.log("native bal: ", yield readAcc.getGasBalance());
     console.log("basket bal: ", yield readAcc.getTokenInfo(_productToBuy));
-    console.log("sale state", yield readAcc.saleIsActive());
-    console.log("whitelist state", yield readAcc.whitelistSaleIsActive());
+    // console.log("sale state", await readAcc.saleIsActive());
+    // console.log("whitelist state", await readAcc.whitelistSaleIsActive());
     yield alpAccount.setSimulationMode(false);
     yield buy(alpAccount, _productToBuy, 2);
     console.log("bought: ", _productToBuy, "of amount: ", 1);

--- a/dist/index.html
+++ b/dist/index.html
@@ -1,0 +1,8 @@
+<html lang="en">
+  <body>
+    <button id="switchToPolygon">
+      Switch to polygon
+    </button>
+  </body>
+  <script src="/index.62f90388.js" defer=""></script>
+</html>

--- a/dist/index.html
+++ b/dist/index.html
@@ -1,8 +1,0 @@
-<html lang="en">
-  <body>
-    <button id="switchToPolygon">
-      Switch to polygon
-    </button>
-  </body>
-  <script src="/index.62f90388.js" defer=""></script>
-</html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alpine-ramp/alpine-defi-sdk",
-  "version": "1.3.99-beta",
+  "version": "1.4.01-beta",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/Multiplyr/defi-sdk.git",

--- a/src/core/AlpineDeFiSDK.ts
+++ b/src/core/AlpineDeFiSDK.ts
@@ -148,7 +148,11 @@ export async function isApproved(product: AlpineProduct, amount?: number): Promi
     polygonLeverage,
   };
 
-  const allowance = await asset.allowance(userAddress, productToSpender[product].address);
+  if (!productToSpender[product]) {
+    throw new Error("Product not found");
+  }
+
+  const allowance = await asset.allowance(userAddress, productToSpender[product]?.address);
   /**
    * If the 'amount' is not specified then we will check the max amount, but
    * we are dividing the max approval amount by 2 because
@@ -185,7 +189,7 @@ export async function approve(product: AlpineProduct, amountAsset?: string): Pro
     dollarAmount: amountAsset || _removeDecimals(MAX_APPROVAL_AMOUNT, decimals),
     tokenAmount: amountAsset || _removeDecimals(MAX_APPROVAL_AMOUNT, decimals),
   };
-  const approveArgs = [product === "alpLarge" ? router.address : contracts[product].address, amount];
+  const approveArgs = [product === "alpLarge" ? router.address : contracts[product]?.address, amount];
   if (SIMULATE) {
     const dryRunInfo = (await blockchainCall(asset, "approve", approveArgs, true)) as GasInfo;
     return { ...basicInfo, ...dryRunInfo };
@@ -242,6 +246,7 @@ export async function mintUSDC(to: string, amountUSDC: number | BigNumber) {
 export async function mintWhitelist(quantity: number, proof: string[]) {
   const contracts = getContracts() as AlpineContracts;
   const { affineGenesis } = contracts;
+  if (!affineGenesis) throw new Error("AffineGenesis contract not found");
   return blockchainCall(affineGenesis, "mintWhitelist", [quantity, proof]);
 }
 
@@ -252,6 +257,7 @@ export async function mintWhitelist(quantity: number, proof: string[]) {
 export async function mint(quantity: number) {
   const contracts = getContracts() as AlpineContracts;
   const { affineGenesis } = contracts;
+  if (!affineGenesis) throw new Error("AffineGenesis contract not found");
   return blockchainCall(affineGenesis, "mint", [quantity]);
 }
 
@@ -262,7 +268,7 @@ export async function mint(quantity: number) {
 export async function isWhitelisted(address: string, proof: string[]): Promise<boolean> {
   const contracts = getContracts() as AlpineContracts;
   const { affineGenesis } = contracts;
-  return affineGenesis.isWhitelisted(address, proof);
+  return affineGenesis?.isWhitelisted(address, proof) ?? false;
 }
 
 /**
@@ -272,7 +278,7 @@ export async function isWhitelisted(address: string, proof: string[]): Promise<b
 export async function whitelistSaleIsActive(): Promise<boolean> {
   const contracts = getContracts() as AlpineContracts;
   const { affineGenesis } = contracts;
-  return affineGenesis.whitelistSaleIsActive();
+  return affineGenesis?.whitelistSaleIsActive() ?? false;
 }
 
 /**
@@ -282,5 +288,5 @@ export async function whitelistSaleIsActive(): Promise<boolean> {
 export async function saleIsActive(): Promise<boolean> {
   const contracts = getContracts() as AlpineContracts;
   const { affineGenesis } = contracts;
-  return affineGenesis.saleIsActive();
+  return affineGenesis?.saleIsActive() ?? false;
 }

--- a/src/core/cache.ts
+++ b/src/core/cache.ts
@@ -110,8 +110,8 @@ export async function getAllContracts(
       router: Router__factory.connect(router.address, provider),
       ewQueue: EmergencyWithdrawalQueue__factory.connect(await alpSave.emergencyWithdrawalQueue(), provider),
       polygonDegen: StrategyVault__factory.connect(polygonDegenData.address, provider),
-      polygonLeverage: Vault__factory.connect(polygonLeverageData.address, provider),
-      affineGenesis: AffineGenesis__factory.connect(affineGenesisData.address, provider),
+      polygonLeverage: chainId === 137 ? Vault__factory.connect(polygonLeverageData.address, provider) : undefined,
+      affineGenesis: chainId === 137 ? AffineGenesis__factory.connect(affineGenesisData.address, provider) : undefined,
     };
   } else if (chainId === 1 || chainId === 5) {
     const ethEarn = Vault__factory.connect(ethEarnData.address, provider);
@@ -119,7 +119,7 @@ export async function getAllContracts(
     const ssvEthUSDEarn = StrategyVault__factory.connect(ssvEthSushiUSDEarn.address, provider);
     const withdrawalEscrow = WithdrawalEscrow__factory.connect(await ssvEthUSDEarn.debtEscrow(), provider);
     const degen = Vault__factory.connect(degenData.address, provider);
-    const ethLeverage = Vault__factory.connect(ethLeverageData.address, provider);
+    const ethLeverage = chainId === 1 ? Vault__factory.connect(ethLeverageData.address, provider) : undefined;
     return {
       ethEarn,
       ethWethEarn,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -71,8 +71,8 @@ export interface PolygonContracts extends BothContracts {
   router: Router;
   ewQueue: EmergencyWithdrawalQueue;
   polygonDegen: StrategyVault;
-  polygonLeverage: Vault;
-  affineGenesis: AffineGenesis;
+  polygonLeverage?: Vault;
+  affineGenesis?: AffineGenesis;
 }
 
 export interface EthContracts extends BothContracts {
@@ -83,7 +83,7 @@ export interface EthContracts extends BothContracts {
   withdrawalEscrow: WithdrawalEscrow;
   router: Router;
   degen: Vault;
-  ethLeverage: Vault;
+  ethLeverage?: Vault;
 }
 
 export interface AlpineContracts extends PolygonContracts, EthContracts {}

--- a/src/frontend/test.ts
+++ b/src/frontend/test.ts
@@ -77,8 +77,8 @@ const buy = async (alpAccount: Account, product: AlpineProduct, amount: number) 
 const main = async () => {
   const alpAccount = new Account();
   const walletType = "metamask";
-  const chainId = 137 as AllowedChainId;
-  const _productToBuy: AlpineProduct = "polygonLeverage";
+  const chainId = 5 as AllowedChainId;
+  const _productToBuy: AlpineProduct = "ethEarn";
 
   console.log(
     `connecting to ${walletType} on chain ${chainId}`,
@@ -92,8 +92,8 @@ const main = async () => {
   console.log("native bal: ", await readAcc.getGasBalance());
   console.log("basket bal: ", await readAcc.getTokenInfo(_productToBuy));
 
-  console.log("sale state", await readAcc.saleIsActive());
-  console.log("whitelist state", await readAcc.whitelistSaleIsActive());
+  // console.log("sale state", await readAcc.saleIsActive());
+  // console.log("whitelist state", await readAcc.whitelistSaleIsActive());
 
   await alpAccount.setSimulationMode(false);
   await buy(alpAccount, _productToBuy, 2);


### PR DESCRIPTION
We have some missing vaults in the testnets that are actually causing the error during the `init()` and as well as the `connect()` to the SDK. These changes are made so that we can have at least the initialization complete to perform or invoke other functions/ features.