### PR TITLE
Resolved issues of alchemy keys having `undefined` values

### DIFF
--- a/dist/core/cache.js
+++ b/dist/core/cache.js
@@ -22,20 +22,19 @@ let CONTRACTS;
 let CHAIN_ID;
 exports.SIMULATE = false;
 const CONTRACT_VERSION = (_a = process.env.CONTRACT_VERSION) !== null && _a !== void 0 ? _a : "test";
-const { ALCHEMY_API_KEY, ALCHEMY_BASE_TESTNET_KEY, ALCHEMY_BASE_MAINNET_KEY } = process.env;
 exports.RPC_URLS = {
     1: constants_1.IS_USING_FORKED_MAINNET && constants_1.FORKED_NODE_URL_FOR_ETH
         ? constants_1.FORKED_NODE_URL_FOR_ETH
-        : `https://eth-mainnet.alchemyapi.io/v2/${ALCHEMY_API_KEY}`,
-    5: `https://eth-goerli.alchemyapi.io/v2/${ALCHEMY_API_KEY}`,
+        : `https://eth-mainnet.alchemyapi.io/v2/${process.env.ALCHEMY_API_KEY}`,
+    5: `https://eth-goerli.alchemyapi.io/v2/${process.env.ALCHEMY_API_KEY}`,
     137: constants_1.IS_USING_FORKED_MAINNET && constants_1.FORKED_NODE_URL_FOR_MATIC
         ? constants_1.FORKED_NODE_URL_FOR_MATIC
-        : `https://polygon-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}`,
-    80001: `https://polygon-mumbai.g.alchemy.com/v2/${ALCHEMY_API_KEY}`,
+        : `https://polygon-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`,
+    80001: `https://polygon-mumbai.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`,
     8453: constants_1.IS_USING_FORKED_MAINNET && constants_1.FORKED_NODE_URL_FOR_BASE
         ? constants_1.FORKED_NODE_URL_FOR_BASE
-        : `https://base-mainnet.g.alchemy.com/v2/${ALCHEMY_BASE_MAINNET_KEY}`,
-    84531: `https://base-mainnet.g.alchemy.com/v2/${ALCHEMY_BASE_TESTNET_KEY}`,
+        : `https://base-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_BASE_MAINNET_KEY}`,
+    84531: `https://base-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_BASE_TESTNET_KEY}`,
 };
 function getProviderByChainId(chainId) {
     exports.PROVIDER = new ethers_1.ethers.providers.StaticJsonRpcProvider(exports.RPC_URLS[chainId]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alpine-ramp/alpine-defi-sdk",
-  "version": "1.4.4-beta",
+  "version": "1.4.41-beta",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/Multiplyr/defi-sdk.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alpine-ramp/alpine-defi-sdk",
-  "version": "1.4.41-beta",
+  "version": "1.4.5-beta",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/Multiplyr/defi-sdk.git",

--- a/src/core/cache.ts
+++ b/src/core/cache.ts
@@ -31,26 +31,24 @@ export let BICONOMY: ethers.providers.Web3Provider | undefined;
 
 const CONTRACT_VERSION = process.env.CONTRACT_VERSION ?? "test";
 
-const { ALCHEMY_API_KEY, ALCHEMY_BASE_TESTNET_KEY, ALCHEMY_BASE_MAINNET_KEY } = process.env;
-
 export let PROVIDER: ethers.providers.StaticJsonRpcProvider;
 
 export const RPC_URLS: { [index: AllowedChainId]: string } = {
   1:
     IS_USING_FORKED_MAINNET && FORKED_NODE_URL_FOR_ETH
       ? FORKED_NODE_URL_FOR_ETH
-      : `https://eth-mainnet.alchemyapi.io/v2/${ALCHEMY_API_KEY}`,
-  5: `https://eth-goerli.alchemyapi.io/v2/${ALCHEMY_API_KEY}`,
+      : `https://eth-mainnet.alchemyapi.io/v2/${process.env.ALCHEMY_API_KEY}`,
+  5: `https://eth-goerli.alchemyapi.io/v2/${process.env.ALCHEMY_API_KEY}`,
   137:
     IS_USING_FORKED_MAINNET && FORKED_NODE_URL_FOR_MATIC
       ? FORKED_NODE_URL_FOR_MATIC
-      : `https://polygon-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}`,
-  80001: `https://polygon-mumbai.g.alchemy.com/v2/${ALCHEMY_API_KEY}`,
+      : `https://polygon-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`,
+  80001: `https://polygon-mumbai.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`,
   8453:
     IS_USING_FORKED_MAINNET && FORKED_NODE_URL_FOR_BASE
       ? FORKED_NODE_URL_FOR_BASE
-      : `https://base-mainnet.g.alchemy.com/v2/${ALCHEMY_BASE_MAINNET_KEY}`,
-  84531: `https://base-mainnet.g.alchemy.com/v2/${ALCHEMY_BASE_TESTNET_KEY}`,
+      : `https://base-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_BASE_MAINNET_KEY}`,
+  84531: `https://base-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_BASE_TESTNET_KEY}`,
 };
 
 export function getProviderByChainId(chainId: AllowedChainId): ethers.providers.StaticJsonRpcProvider {


### PR DESCRIPTION
We are having weird issues in the app where the SDK can't access the ENV variables (from the frontend) as the variables were declared using the spread operator. But surprisingly it works if we directly use as before `process.env.ALCHEMY_API_KEY`. This might be because of the transpilers or something related to the babel.